### PR TITLE
avoid deprecated `Gtk.Button.set_focus_on_click`

### DIFF
--- a/src/Dialogs/PostDialog.vala
+++ b/src/Dialogs/PostDialog.vala
@@ -41,7 +41,7 @@ public class Tootle.PostDialog : Gtk.Dialog {
         visibility.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
         visibility.get_style_context ().remove_class ("image-button");
         visibility.can_default = false;
-        visibility.set_focus_on_click (false);
+        (visibility as Gtk.Widget).set_focus_on_click (false);
         
         attach = new Gtk.Button.from_icon_name ("mail-attachment-symbolic");
         attach.tooltip_text = _("Add Media");
@@ -49,7 +49,7 @@ public class Tootle.PostDialog : Gtk.Dialog {
         attach.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
         attach.get_style_context ().remove_class ("image-button");
         attach.can_default = false;
-        attach.set_focus_on_click (false);
+        (attach as Gtk.Widget).set_focus_on_click (false);
         attach.clicked.connect (() => attachments.select ());
         
         spoiler = new ImageToggleButton ("image-red-eye-symbolic");

--- a/src/Views/AccountView.vala
+++ b/src/Views/AccountView.vala
@@ -93,7 +93,7 @@ public class Tootle.AccountView : TimelineView {
         button_menu.image = new Gtk.Image.from_icon_name ("view-more-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
         button_menu.tooltip_text = _("More Actions");
         button_menu.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-        button_menu.set_focus_on_click (false);
+        (button_menu as Gtk.Widget).set_focus_on_click (false);
         button_menu.can_default = false;
         button_menu.can_focus = false;
         button_menu.popup = menu;
@@ -192,7 +192,7 @@ public class Tootle.AccountView : TimelineView {
             btn = new Gtk.Button.from_icon_name (name, Gtk.IconSize.LARGE_TOOLBAR);
             
         btn.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-        btn.set_focus_on_click (false);
+        (btn as Gtk.Widget).set_focus_on_click (false);
         btn.can_default = false;
         btn.can_focus = false;
         


### PR DESCRIPTION
It was deprecated in favor of `Gtk.Widget.set_focus_on_click` in GTK+3.20: https://developer.gnome.org/gtk3/stable/GtkButton.html#gtk-button-set-focus-on-click