### PR TITLE
fix memory leak

### DIFF
--- a/src/ImageCache.vala
+++ b/src/ImageCache.vala
@@ -111,19 +111,23 @@ public class Tootle.ImageCache : GLib.Object {
         Soup.Message? msg = in_progress.get(ci);
         if (msg == null) {
             msg = new Soup.Message("GET", uri);
-            msg.finished.connect(() => {
+            ulong id = 0;
+            id = msg.finished.connect(() => {
                 debug("Caching %s@%d", uri, size);
                 var data = msg.response_body.data;
                 var stream = new MemoryInputStream.from_data (data);
                 var pixbuf = new Gdk.Pixbuf.from_stream_at_scale (stream, size, size, true);
                 store_pixbuf(ci, pixbuf);
                 cb(pixbuf);
+                msg.disconnect(id);
             });
             in_progress[ci] = msg;
             network.queue_custom (msg);
         } else {
-            msg.finished.connect_after(() => {
+            ulong id = 0;
+            id = msg.finished.connect(() => {
                 cb(pixbufs[ci]);
+                msg.disconnect(id);
             });
         }
     }

--- a/src/Widgets/NotificationWidget.vala
+++ b/src/Widgets/NotificationWidget.vala
@@ -48,8 +48,8 @@ public class Tootle.NotificationWidget : Gtk.Grid {
         }
         
         destroy.connect (() => {
-            if(separator != null)
-                separator.destroy ();
+            separator = null;
+            status_widget = null;
         });
         
         if (notification.status != null){


### PR DESCRIPTION
First, avoid leaking SoupMessages by disconnecting the callbacks that reference them after they fire.

Second, free the StatusWidget owned by NotificationWidgets.

Somehow this is what seems to do it.Try refreshing several times for yourself.

Closes #9.