### PR TITLE
Fix error while parsing URLs

### DIFF
--- a/src/Dialogs/NewAccountDialog.vala
+++ b/src/Dialogs/NewAccountDialog.vala
@@ -91,8 +91,8 @@ public class Tootle.NewAccountDialog : Gtk.Dialog {
         instance = "https://" + instance_entry.text
             .replace ("/", "")
             .replace (":", "")
-            .replace ("http", "")
-            .replace ("https", "");
+            .replace ("https", "")
+            .replace ("http", "");
         code = code_entry.text;
             
         if (this.client_id == null || this.client_secret == null) {


### PR DESCRIPTION
Fixes #74. “http” being replaced before “https” left an extra “s” that did not get cleaned when an URL starting with “https” was entered.