### PR TITLE
Use emblem-favorite-symbolic for favoriting.

### DIFF
--- a/src/API/NotificationType.vala
+++ b/src/API/NotificationType.vala
@@ -71,7 +71,7 @@ public enum Tootle.NotificationType {
             case REBLOG:
                 return "media-playlist-repeat-symbolic";
             case FAVORITE:
-                return "help-about-symbolic";
+                return "emblem-favorite-symbolic";
             case FOLLOW:
             case FOLLOW_REQUEST:
                 return "contact-new-symbolic";

--- a/src/Widgets/StatusWidget.vala
+++ b/src/Widgets/StatusWidget.vala
@@ -86,7 +86,7 @@ public class Tootle.StatusWidget : Gtk.EventBox {
             if (reblog.sensitive)
                 this.status.get_formal ().set_reblogged (reblog.get_active ());
         });
-        favorite = new ImageToggleButton ("help-about-symbolic");
+        favorite = new ImageToggleButton ("emblem-favorite-symbolic");
         favorite.set_action ();
         favorite.tooltip_text = _("Favorite");
         favorite.toggled.connect (() => {


### PR DESCRIPTION
This commit changes the favorite icon from the less obvious `help-about-symbolic` to `emblem-favorite-symbolic`, which has been tested / is known to be available in the following icon themes:

- Adwaita
- Arc
- Breeze
- La Capitaine
- Papirus
- Surfn
- elementary