### PR TITLE
src/Html.vala: strip data-user attribute

### DIFF
--- a/src/Html.vala
+++ b/src/Html.vala
@@ -13,7 +13,7 @@ public class Tootle.Html {
         .replace("<p>", "")
         .replace("</p>", "\n\n");
 
-        var html_params = new Regex("(class|target|rel)=\"(.|\n)*?\"", RegexCompileFlags.CASELESS);
+        var html_params = new Regex("(class|target|rel|data-.*)=\"(.|\n)*?\"", RegexCompileFlags.CASELESS);
         var simplified = html_params.replace(divided, -1, 0, "");
 
         while (simplified.has_suffix ("\n"))

--- a/src/Html.vala
+++ b/src/Html.vala
@@ -13,7 +13,7 @@ public class Tootle.Html {
         .replace("<p>", "")
         .replace("</p>", "\n\n");
 
-        var html_params = new Regex("(class|target|rel|data-.*)=\"(.|\n)*?\"", RegexCompileFlags.CASELESS);
+        var html_params = new Regex("(class|target|rel|data-user|data-tag)=\"(.|\n)*?\"", RegexCompileFlags.CASELESS);
         var simplified = html_params.replace(divided, -1, 0, "");
 
         while (simplified.has_suffix ("\n"))


### PR DESCRIPTION
Fixes: Failed to set text '<span><a data-user="…" href="…">@<span>…</span></a></span> …' from markup
due to error parsing markup: Attribute 'data-user' is not allowed on the <a> tag on line 1 char 75