### PR TITLE
#76 Add reading character limit from the server if available

### DIFF
--- a/src/Dialogs/Compose.vala
+++ b/src/Dialogs/Compose.vala
@@ -19,7 +19,7 @@ public class Tootle.Dialogs.Compose : Dialog {
     protected API.Status? replying_to;
     protected API.Status? redrafting;
     protected API.StatusVisibility visibility_opt = API.StatusVisibility.PUBLIC;
-    protected int char_limit;
+    protected int64 char_limit;
 
     public Compose (API.Status? _replying_to = null, API.Status? _redrafting = null) {
         border_width = 6;
@@ -27,7 +27,7 @@ public class Tootle.Dialogs.Compose : Dialog {
         resizable = true;
         title = _("Toot");
         transient_for = window;
-        char_limit = settings.char_limit;
+        char_limit = accounts.formal.status_char_limit ?? settings.char_limit;
         replying_to = _replying_to;
         redrafting = _redrafting;
 

--- a/src/InstanceAccount.vala
+++ b/src/InstanceAccount.vala
@@ -8,6 +8,7 @@ public class Tootle.InstanceAccount : Object {
     public string client_id {get; set;}
     public string client_secret {get; set;}
     public string token {get; set;}
+    public int64? status_char_limit {get; set;}
 
     public int64 last_seen_notification {get; set; default = 0;}
     public bool has_unread_notifications {get; set; default = false;}
@@ -69,6 +70,10 @@ public class Tootle.InstanceAccount : Object {
         builder.add_int_value (last_seen_notification);
         builder.set_member_name ("has_unread_notifications");
         builder.add_boolean_value (has_unread_notifications);
+        if (status_char_limit != null) {
+            builder.set_member_name ("status_char_limit");
+            builder.add_int_value (status_char_limit);
+        }
 
         builder.set_member_name ("cached_notifications");
         builder.begin_array ();
@@ -93,6 +98,11 @@ public class Tootle.InstanceAccount : Object {
         acc.token = obj.get_string_member ("token");
         acc.last_seen_notification = obj.get_int_member ("last_seen_notification");
         acc.has_unread_notifications = obj.get_boolean_member ("has_unread_notifications");
+        if (obj.has_member("status_char_limit")) {
+            acc.status_char_limit = obj.get_int_member ("status_char_limit");
+        } else {
+            acc.status_char_limit = null;
+        }
 
         var notifications = obj.get_array_member ("cached_notifications");
         notifications.foreach_element ((arr, i, node) => {


### PR DESCRIPTION
**Proposal**

Make possibility to read character limits from the server (which currently works on pleroma although). I don't think that character limit changes too often, so currently it is read only when creating new account. Probably can add re-reading character limit within some time period later.

Have tested with [mastodon.technology](https://mastodon.technology) and [pleroma.site](https://pleroma.site) instances. Worked good, found no crashes or issues.

Relates to #76 