### PR TITLE
add flatpak manifest

### DIFF
--- a/com.github.bleakgrey.tootle.json
+++ b/com.github.bleakgrey.tootle.json
@@ -1,0 +1,66 @@
+{
+  "app-id": "com.github.bleakgrey.tootle",
+  "runtime": "org.gnome.Platform",
+  "sdk": "org.gnome.Sdk",
+  "runtime-version": "3.36",
+  "command": "com.github.bleakgrey.tootle",
+  "finish-args": [
+    "--share=network",
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--socket=wayland",
+    "--filesystem=xdg-run/dconf",
+    "--filesystem=~/.config/dconf:ro",
+    "--talk-name=ca.desrt.dconf",
+    "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+  ],
+  "cleanup": [
+    "/include",
+    "/lib/pkgconfig",
+    "/man",
+    "/share/doc",
+    "/share/gtk-doc",
+    "/share/man",
+    "/share/pkgconfig",
+    "*.la",
+    "*.a"
+  ],
+  "modules": [
+    {
+      "name": "libhandy",
+      "buildsystem": "meson",
+      "builddir": true,
+      "config-opts": [
+        "-Dexamples=false",
+        "-Dtests=false"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://gitlab.gnome.org/GNOME/libhandy.git"
+        }
+      ]
+    },
+    {
+      "name": "libgranite",
+      "buildsystem": "meson",
+      "builddir": true,
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/elementary/granite.git"
+        }
+      ]
+    },
+    {
+      "name": "tootle",
+      "builddir": true,
+      "buildsystem": "meson",
+      "sources": [{
+        "type": "git",
+        "url": "https://github.com/bleakgrey/tootle.git"
+      }]
+    }
+
+  ]
+}


### PR DESCRIPTION
By adding the manifest, people can now build the project using
`flatpak-builder` or just by cloning it with gnome-builder and
hitting run.