### PR TITLE
Add missing dependency on libhandy-1-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,7 @@ Build-Depends: meson,
                libgtk-3-dev (>= 3.22.0),
                libglib2.0-dev (>= 2.30.0),
                libgee-0.8-dev (>= 0.8.5),
+               libhandy-1-dev,
                libsoup2.4-dev,
                libjson-glib-dev
 Standards-Version: 4.1.5


### PR DESCRIPTION
Add missing dependency on libhandy-1-dev.

Without this the package doesn't build for me, but after it still doesn't bundle the tootle executable.
