### PR TITLE
Don't clean the screen when building. Stop installation on errors.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-clear
+set -e
 meson build
 cd build
 ninja


### PR DESCRIPTION
The controversial bit (`- clear`):
I don't expect a build script to clean my terminal screen. I may have something "important" on it.
If you want to easily distinguish between the old output and the new one, consider using a bigger or more noticeable terminal prompt, by editing your `.bashrc` or equivalent. For example, I added a `\n` before the default bash prompt, so i have more space between each command i run.

The actual improvement (`+ set -e`):
The install script should stop when the build fails.
I was missing some dependencies, so `meson build` failed, but the install.sh script kept executing, spamming useless errors.
By setting `set -e` the bash script stops at the first error encountered. 
