### PR TITLE
Include libgirepository1.0-dev as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ If the options above are not available to you, you can build the app from source
     - [x] libsoup2.4-dev
     - [x] libgranite-dev
     - [x] libjson-glib-dev
+    - [x] libgirepository1.0-dev
     - [ ] libhandy-1.0-dev (>= 0.83.0)
 
     *Note: Unchecked items will be installed automatically if not present in the system.*


### PR DESCRIPTION
I have to install this manually to get it to build on Debian.