### PR TITLE
Fix login on pleroma (/api/v1/apps)

### DIFF
--- a/src/Dialogs/NewAccount.vala
+++ b/src/Dialogs/NewAccount.vala
@@ -3,7 +3,7 @@ using Gtk;
 [GtkTemplate (ui = "/com/github/bleakgrey/tootle/ui/dialogs/new_account.ui")]
 public class Tootle.Dialogs.NewAccount: Gtk.Window {
 
-	const string scopes = "read%20write%20follow";
+	const string scopes = "read write follow";
 
 	protected bool is_working { get; set; default = false; }
 	protected string? redirect_uri { get; set; }
@@ -132,10 +132,10 @@ public class Tootle.Dialogs.NewAccount: Gtk.Window {
 
 		var msg = new Request.POST (@"/api/v1/apps")
 			.with_account (account)
-			.with_param ("client_name", Build.NAME)
-			.with_param ("website", Build.WEBSITE)
-			.with_param ("scopes", scopes)
-			.with_param ("redirect_uris", redirect_uri = setup_redirect_uri ());
+			.with_form_data ("client_name", Build.NAME)
+			.with_form_data ("website", Build.WEBSITE)
+			.with_form_data ("scopes", scopes)
+			.with_form_data ("redirect_uris", redirect_uri = setup_redirect_uri ());
 		yield msg.await ();
 
 		var root = network.parse (msg);

--- a/src/Request.vala
+++ b/src/Request.vala
@@ -7,6 +7,7 @@ public class Tootle.Request : Soup.Message {
 	Network.SuccessCallback? cb;
 	Network.ErrorCallback? error_cb;
 	HashMap<string, string>? pars;
+	Soup.Multipart? form_data;
 	weak InstanceAccount? account;
 	bool needs_token = false;
 
@@ -67,6 +68,13 @@ public class Tootle.Request : Soup.Message {
 		return this;
 	}
 
+	public Request with_form_data (string name, string val) {
+		if (form_data == null)
+			form_data = new Soup.Multipart(FORM_MIME_TYPE_MULTIPART);
+		form_data.append_form_string(name, val);
+		return this;
+	}
+
 	public Request exec () {
 		var parameters = "";
 		if (pars != null) {
@@ -88,6 +96,9 @@ public class Tootle.Request : Soup.Message {
 				return true;
 			});
 		}
+
+		if (form_data != null)
+			form_data.to_message(request_headers, request_body);
 
 		if (needs_token) {
 			if (account == null) {


### PR DESCRIPTION
According to mastodon spec you are supposed to send the data as form data,
not in the uri (https://docs.joinmastodon.org/methods/apps/).
This was an issue in pleroma until
https://git.pleroma.social/pleroma/pleroma/-/merge_requests/2387.
But with this change the code follows the documentation and it also
works with older pleroma version.

This should fix #228.

I have only tested this change with pleroma