### PR TITLE
Fix markup lists and inline image (pleroma)

### DIFF
--- a/src/Html.vala
+++ b/src/Html.vala
@@ -32,6 +32,14 @@ public class Tootle.Html {
 			while (simplified.has_suffix ("\n"))
 				simplified = simplified.slice (0, simplified.last_index_of ("\n"));
 
+			var html_img_src = new Regex ("<img[ ]+(src)=\"([^\"]*)\"(.|\n)*?\\/>", RegexCompileFlags.CASELESS);
+			simplified = html_img_src.replace_eval(simplified, simplified.length, 0, 0, (match_info, result) => {
+				var src = match_info.fetch(2);
+				// TODO: Show image in-line instead of a link to the image
+				result.append_printf("<a href=\"%s\">%s</a>", src, src);
+				return false;
+			});
+
 			return simplified;
 		}
 		catch (Error e) {
@@ -41,7 +49,7 @@ public class Tootle.Html {
 	}
 
 	public static string replace_with_pango_markup (string str) {
-		return str
+		var result = str
 			.replace("<strong>", "<b>")
 			.replace("</strong>", "</b>")
 			.replace("<em>", "<i>")
@@ -50,6 +58,70 @@ public class Tootle.Html {
 			.replace("</code>", "</span>\n")
 			.replace("<del>", "<s>")
 			.replace("</del>", "</s>");
+		return list_tags_to_text(result);
+	}
+
+	private enum ListType {
+		UL,
+		OL
+	}
+
+	private struct ListTag {
+		ListType type;
+		int counter;
+	}
+
+	public static string list_tags_to_text (string str) {
+		try {
+			var list_tags = new Regex ("<(/?)(ul|ol|li)>", RegexCompileFlags.CASELESS);
+			var list_tag_stack = new Array<ListTag> ();
+			return list_tags.replace_eval(str, str.length, 0, 0, (match_info, result) => {
+				var is_start_tag = match_info.fetch(1) == "";
+				var match = match_info.fetch(2);
+				if (match == "ul") {
+					if (is_start_tag) {
+						var list_tag = ListTag();
+						list_tag.type = ListType.UL;
+						list_tag.counter = 1;
+						list_tag_stack.append_val(list_tag);
+					} else {
+						if (list_tag_stack.length > 0)
+							list_tag_stack.remove_index_fast (list_tag_stack.length - 1);
+					}
+				} else if (match == "ol") {
+					if (is_start_tag) {
+						var list_tag = ListTag();
+						list_tag.type = ListType.OL;
+						list_tag.counter = 1;
+						list_tag_stack.append_val(list_tag);
+					} else {
+						if (list_tag_stack.length > 0)
+							list_tag_stack.remove_index_fast (list_tag_stack.length - 1);
+					}
+				} else if (match == "li") {
+					if (is_start_tag) {
+						if (list_tag_stack.length > 0) {
+							var last_tag_item = list_tag_stack.index(list_tag_stack.length - 1);
+							if (last_tag_item.type == ListType.UL)
+								result.append("• ");
+							else if (last_tag_item.type == ListType.OL)
+								result.append_printf("%d. ", last_tag_item.counter);
+							last_tag_item.counter++;
+						}
+					} else {
+						if (list_tag_stack.length > 0) {
+							if( list_tag_stack.index(list_tag_stack.length - 1).counter > 1)
+								list_tag_stack.index(list_tag_stack.length - 1).counter--;
+							result.append("\n");
+						}
+					}
+				}
+				return false;
+			});
+		} catch (Error e) {
+			warning (e.message);
+			return str;
+		}
 	}
 
 	public static string uri_encode (string str) {

--- a/src/Html.vala
+++ b/src/Html.vala
@@ -32,14 +32,6 @@ public class Tootle.Html {
 			while (simplified.has_suffix ("\n"))
 				simplified = simplified.slice (0, simplified.last_index_of ("\n"));
 
-			var html_img_src = new Regex ("<img[ ]+(src)=\"([^\"]*)\"(.|\n)*?\\/>", RegexCompileFlags.CASELESS);
-			simplified = html_img_src.replace_eval(simplified, simplified.length, 0, 0, (match_info, result) => {
-				var src = match_info.fetch(2);
-				// TODO: Show image in-line instead of a link to the image
-				result.append_printf("<a href=\"%s\">%s</a>", src, src);
-				return false;
-			});
-
 			return simplified;
 		}
 		catch (Error e) {
@@ -58,6 +50,19 @@ public class Tootle.Html {
 			.replace("</code>", "</span>\n")
 			.replace("<del>", "<s>")
 			.replace("</del>", "</s>");
+
+		try {
+			var html_img_src = new Regex ("<img[ ]+(src)=\"([^\"]*)\"(.|\n)*?\\/>", RegexCompileFlags.CASELESS);
+			result = html_img_src.replace_eval(result, result.length, 0, 0, (match_info, result) => {
+				var src = match_info.fetch(2);
+				// TODO: Show image in-line instead of a link to the image
+				result.append_printf("<a href=\"%s\">%s</a>", src, src);
+				return false;
+			});
+		} catch (Error e) {
+			warning (e.message);
+		}
+
 		return list_tags_to_text(result);
 	}
 


### PR DESCRIPTION
Without this change it shows Lorem Lipsum placeholder text if a post
contains lists or inline images.

Right now it will display inline images as hyperlinks, but it should
probably be changed to download the image and display it inline.
That should be done in another task unless its simple to do.

I also tried to fallback to non markup mode for the label if pango fails
to parse the markup but pango fails to parse <a> tags, even though
setting <a> tags works if you set them directly with label = ...