### PR TITLE
MainWindow: Transition fix and cleanup fix

### DIFF
--- a/data/ui/dialogs/main.ui
+++ b/data/ui/dialogs/main.ui
@@ -12,6 +12,8 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="can_swipe_back">True</property>
+        <signal name="notify::transition-running" handler="on_child_transition"/>
+        <signal name="notify::visible-child" handler="on_child_transition"/>
         <child>
           <placeholder/>
         </child>

--- a/data/ui/dialogs/main.ui
+++ b/data/ui/dialogs/main.ui
@@ -13,7 +13,6 @@
         <property name="can_focus">False</property>
         <property name="transition_type">slide</property>
         <property name="can_swipe_back">True</property>
-        <property name="can_swipe_forward">True</property>
         <child>
           <placeholder/>
         </child>

--- a/data/ui/dialogs/main.ui
+++ b/data/ui/dialogs/main.ui
@@ -11,7 +11,6 @@
       <object class="HdyDeck" id="deck">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="transition_type">slide</property>
         <property name="can_swipe_back">True</property>
         <child>
           <placeholder/>

--- a/src/Dialogs/MainWindow.vala
+++ b/src/Dialogs/MainWindow.vala
@@ -40,26 +40,18 @@ public class Tootle.Dialogs.MainWindow: Hdy.Window, ISavedWindow {
 	}
 
 	public bool back () {
-		var children = deck.get_children ();
-		unowned var current = children.find (deck.visible_child);
-		if (current != null) {
-			unowned var prev = current.prev;
-			if (current.prev != null) {
-				deck.visible_child = prev.data;
-				(current.data as Views.Base).unused = true;
-				Timeout.add (deck.transition_duration, clean_unused_views);
-			}
-		}
+		deck.navigate (Hdy.NavigationDirection.BACK);
 		return true;
 	}
 
-	bool clean_unused_views () {
-		deck.get_children ().foreach (c => {
-			var view = c as Views.Base;
-			if (view != null && view.unused)
-				view.destroy ();
-		});
-		return Source.REMOVE;
+	[GtkCallback]
+	void on_child_transition () {
+		if (deck.transition_running)
+			return;
+
+		Widget unused_child;
+		while ((unused_child = deck.get_adjacent_child (Hdy.NavigationDirection.FORWARD)) != null)
+			unused_child.destroy ();
 	}
 
 	public override bool delete_event (Gdk.EventAny event) {

--- a/src/Views/Base.vala
+++ b/src/Views/Base.vala
@@ -10,7 +10,6 @@ public class Tootle.Views.Base : Box {
 	public string label { get; set; default = ""; }
 	public bool needs_attention { get; set; default = false; }
 	public bool current { get; set; default = false; }
-	public bool unused { get; set; default = false; }
 	public SimpleActionGroup? actions { get; set; }
 
 	public Container content { get; set; }


### PR DESCRIPTION
The fixes the semantics of the transition by forbidding swiping forward (there should be nowhere to swipe to!) and by using the `over` transition type.

This also cleanly cleans the unneeded views up, dropping a timeout hack and making it work even when swiping back.