### PR TITLE
Introduce MarkupView widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Simple [Mastodon](https://github.com/tootsuite/mastodon) client for Linux
     valac | 0.48
     libglib-2.0-dev | 2.30.0
     libjson-glib-dev | 1.4.4
+    libxml2-dev | 2.9.10
     libgee-0.8-dev | 0.8.5 
     libsoup2.4-dev | 2.64
     libgtk-3-dev | 3.22.0 

--- a/data/app.css
+++ b/data/app.css
@@ -58,3 +58,10 @@
 .ttl-large-body {
   font-size: 110%;
 }
+
+.ttl-code {
+	font-family: monospace;
+	padding: 12px;
+	background: rgba(150,150,150,.1);
+	border-radius: 6px;
+}

--- a/data/ui/views/base.ui
+++ b/data/ui/views/base.ui
@@ -67,6 +67,7 @@
                             <property name="can_focus">False</property>
                             <property name="vhomogeneous">False</property>
                             <property name="transition_type">crossfade</property>
+                            <property name="interpolate_size">True</property>
                             <child>
                               <object class="GtkBox" id="status">
                                 <property name="visible">True</property>

--- a/data/ui/views/profile_header.ui
+++ b/data/ui/views/profile_header.ui
@@ -107,6 +107,7 @@
                 <property name="margin_right">8</property>
                 <property name="margin_top">8</property>
                 <property name="margin_bottom">8</property>
+                <property name="selectable">True</property>
               </object>
             </child>
           </object>

--- a/data/ui/views/profile_header.ui
+++ b/data/ui/views/profile_header.ui
@@ -100,16 +100,13 @@
             <property name="activatable">False</property>
             <property name="selectable">False</property>
             <child>
-              <object class="TootleWidgetsRichLabel" id="note">
+              <object class="TootleWidgetsMarkupView" id="note">
                 <property name="visible">True</property>
-                <property name="wrap">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_left">8</property>
                 <property name="margin_right">8</property>
                 <property name="margin_top">8</property>
                 <property name="margin_bottom">8</property>
-                <property name="selectable">True</property>
-                <property name="width_chars">25</property>
               </object>
             </child>
           </object>

--- a/data/ui/widgets/profile_field_row.ui
+++ b/data/ui/widgets/profile_field_row.ui
@@ -48,6 +48,7 @@
             <property name="wrap">True</property>
             <property name="wrap_mode">word-char</property>
             <property name="xalign">0</property>
+            <property name="markup">allow</property>
           </object>
           <packing>
             <property name="left_attach">2</property>

--- a/data/ui/widgets/status.ui
+++ b/data/ui/widgets/status.ui
@@ -57,6 +57,7 @@
             <property name="xalign">0</property>
             <property name="margin-bottom">8</property>
             <property name="track_visited_links">false</property>
+            <property name="markup">trust</property>
             <style>
               <class name="title-4"/>
             </style>

--- a/data/ui/widgets/status.ui
+++ b/data/ui/widgets/status.ui
@@ -241,15 +241,10 @@
                     <property name="orientation">vertical</property>
                     <property name="spacing">8</property>
                     <child>
-                      <object class="TootleWidgetsRichLabel" id="content">
+                      <object class="TootleWidgetsMarkupView" id="content">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="label">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.</property>
-                        <property name="wrap">True</property>
-                        <property name="wrap_mode">word-char</property>
-                        <property name="width_chars">15</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>

--- a/data/ui/widgets/status.ui
+++ b/data/ui/widgets/status.ui
@@ -92,13 +92,14 @@
               </packing>
             </child>
             <child>
-              <object class="TootleWidgetsRichLabel" id="handle_label">
+              <object class="GtkLabel" id="handle_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="no">Handle</property>
                 <property name="opacity">0.5</property>
                 <property name="ellipsize">end</property>
                 <property name="single_line_mode">True</property>
+                <property name="xalign">0</property>
                 <style>
                   <class name="body"/>
                 </style>
@@ -144,11 +145,12 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="TootleWidgetsRichLabel" id="date_label">
+                  <object class="GtkLabel" id="date_label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="no">Yesterday</property>
                     <property name="opacity">0.5</property>
+                    <property name="xalign">0</property>
                     <style>
                       <class name="body"/>
                     </style>

--- a/meson.build
+++ b/meson.build
@@ -96,6 +96,7 @@ executable(
     'src/Widgets/Attachment/Slot.vala',
     'src/Widgets/Attachment/Picture.vala',
     'src/Widgets/AdaptiveButton.vala',
+    'src/Widgets/MarkupView.vala',
     'src/Dialogs/ISavedWindow.vala',
     'src/Dialogs/NewAccount.vala',
     'src/Dialogs/MainWindow.vala',

--- a/meson.build
+++ b/meson.build
@@ -96,6 +96,7 @@ executable(
     'src/Widgets/Attachment/Slot.vala',
     'src/Widgets/Attachment/Picture.vala',
     'src/Widgets/AdaptiveButton.vala',
+    'src/Widgets/MarkupPolicy.vala',
     'src/Widgets/MarkupView.vala',
     'src/Dialogs/ISavedWindow.vala',
     'src/Dialogs/NewAccount.vala',

--- a/meson.build
+++ b/meson.build
@@ -126,6 +126,7 @@ executable(
         dependency('gee-0.8', version: '>=0.8.5'),
         dependency('libsoup-2.4'),
         dependency('json-glib-1.0', version: '>=1.4.4'),
+        dependency('libxml-2.0'),
         libhandy_dep,
     ],
     install: true,

--- a/src/API/Attachment.vala
+++ b/src/API/Attachment.vala
@@ -63,7 +63,7 @@ public class Tootle.API.Attachment : Entity {
 
 		var descr_param = "";
 		if (descr != null && descr.replace (" ", "") != "") {
-			descr_param = "?description=" + Html.uri_encode (descr);
+			descr_param = "?description=" + HtmlUtils.uri_encode (descr);
 		}
 
 		var buffer = new Soup.Buffer.take (contents);

--- a/src/API/Status.vala
+++ b/src/API/Status.vala
@@ -68,9 +68,9 @@ public class Tootle.API.Status : Entity, Widgetizable {
         if (account.note == "")
             content = "";
         else if ("\n" in account.note)
-            content = Html.remove_tags (account.note.split ("\n")[0]);
+            content = HtmlUtils.remove_tags (account.note.split ("\n")[0]);
         else
-            content = Html.remove_tags (account.note);
+            content = HtmlUtils.remove_tags (account.note);
 	}
 
     public override Gtk.Widget to_widget () {

--- a/src/API/Status.vala
+++ b/src/API/Status.vala
@@ -68,9 +68,9 @@ public class Tootle.API.Status : Entity, Widgetizable {
         if (account.note == "")
             content = "";
         else if ("\n" in account.note)
-            content = HtmlUtils.remove_tags (account.note.split ("\n")[0]);
+            content = account.note.split ("\n")[0];
         else
-            content = HtmlUtils.remove_tags (account.note);
+            content = account.note;
 	}
 
     public override Gtk.Widget to_widget () {

--- a/src/Dialogs/Compose.vala
+++ b/src/Dialogs/Compose.vala
@@ -110,7 +110,7 @@ public class Tootle.Dialogs.Compose : Hdy.Window {
 			cw.text = status.spoiler_text;
 			cw_button.active = true;
 		}
-		content.buffer.text = Html.remove_tags (status.content);
+		content.buffer.text = HtmlUtils.remove_tags (status.content);
 
 		validate ();
 		set_media_mode (status.has_media ());
@@ -291,11 +291,11 @@ public class Tootle.Dialogs.Compose : Hdy.Window {
 		var req = new Request.POST (@"/api/v1/statuses?$media_param")
 			.with_account (accounts.active)
 			.with_param ("visibility", visibility_popover.selected.to_string ())
-			.with_param ("status", Html.uri_encode (status.content));
+			.with_param ("status", HtmlUtils.uri_encode (status.content));
 
 		if (cw_button.active) {
 			req.with_param ("sensitive", "true");
-			req.with_param ("spoiler_text", Html.uri_encode (cw.text));
+			req.with_param ("spoiler_text", HtmlUtils.uri_encode (cw.text));
 		}
 		if (status.in_reply_to_id != null)
 			req.with_param ("in_reply_to_id", status.in_reply_to_id);

--- a/src/Html.vala
+++ b/src/Html.vala
@@ -1,4 +1,4 @@
-public class Tootle.Html {
+public class Tootle.HtmlUtils {
 
 	public const string FALLBACK_TEXT = _("[ There was an error parsing this text :c ]");
 

--- a/src/Html.vala
+++ b/src/Html.vala
@@ -4,7 +4,9 @@ public class Tootle.HtmlUtils {
 
 	public static string remove_tags (string content) {
 		try {
+			//TODO: remove this when simplify() uses the HTML parsing class
 			var fixed_paragraphs = simplify (content);
+
 			var all_tags = new Regex ("<(.|\n)*?>", RegexCompileFlags.CASELESS);
 			return Widgets.RichLabel.restore_entities (all_tags.replace (fixed_paragraphs, -1, 0, ""));
 		}
@@ -14,6 +16,8 @@ public class Tootle.HtmlUtils {
 		}
 	}
 
+	//TODO: Perhaps this should use the HTML parser class
+	//      since we depend on it anyway
 	public static string simplify (string str) {
 		try {
 			var divided = str
@@ -32,8 +36,8 @@ public class Tootle.HtmlUtils {
 			return simplified;
 		}
 		catch (Error e) {
-			warning (e.message);
-			return FALLBACK_TEXT;
+			warning (@"Can't simplify string \"$str\":\n$(e.message)");
+			return remove_tags (str);
 		}
 	}
 

--- a/src/InstanceAccount.vala
+++ b/src/InstanceAccount.vala
@@ -63,13 +63,13 @@ public class Tootle.InstanceAccount : API.Account, IStreamListener {
 	}
 
 	void show_notification (API.Notification obj) {
-		var title = Html.remove_tags (obj.kind.get_desc (obj.account));
+		var title = HtmlUtils.remove_tags (obj.kind.get_desc (obj.account));
 		var notification = new GLib.Notification (title);
 		if (obj.status != null) {
 			var body = "";
 			body += domain;
 			body += "\n";
-			body += Html.remove_tags (obj.status.content);
+			body += HtmlUtils.remove_tags (obj.status.content);
 			notification.set_body (body);
 		}
 

--- a/src/Views/Profile.vala
+++ b/src/Views/Profile.vala
@@ -49,7 +49,7 @@ public class Tootle.Views.Profile : Views.Timeline {
 		note_row = builder.get_object ("note_row") as ListBoxRow;
 		var note = builder.get_object ("note") as Widgets.RichLabel;
 		profile.bind_property ("note", note, "text", BindingFlags.SYNC_CREATE, (b, src, ref target) => {
-			var text = Html.simplify ((string) src);
+			var text = HtmlUtils.simplify ((string) src);
 			target.set_string (text);
 			note_row.visible = text != "";
 			return true;

--- a/src/Views/Profile.vala
+++ b/src/Views/Profile.vala
@@ -47,9 +47,9 @@ public class Tootle.Views.Profile : Views.Timeline {
 		profile.bind_property ("display-name", handle, "text", BindingFlags.SYNC_CREATE);
 
 		note_row = builder.get_object ("note_row") as ListBoxRow;
-		var note = builder.get_object ("note") as Widgets.RichLabel;
-		profile.bind_property ("note", note, "text", BindingFlags.SYNC_CREATE, (b, src, ref target) => {
-			var text = HtmlUtils.simplify ((string) src);
+		var note = builder.get_object ("note") as Widgets.MarkupView;
+		profile.bind_property ("note", note, "content", BindingFlags.SYNC_CREATE, (b, src, ref target) => {
+			var text = (string) src;
 			target.set_string (text);
 			note_row.visible = text != "";
 			return true;

--- a/src/Widgets/Conversation.vala
+++ b/src/Widgets/Conversation.vala
@@ -19,7 +19,7 @@ public class Tootle.Widgets.Conversation : Widgets.Status {
 		owned get {
 			var label = "";
 			foreach (API.Account account in conversation.accounts) {
-				label += "<b>" + HtmlUtils.simplify (account.display_name) + "</b>";
+				label += account.display_name;
 				if (conversation.accounts.last () != account)
 					label += ", ";
 			}

--- a/src/Widgets/Conversation.vala
+++ b/src/Widgets/Conversation.vala
@@ -19,7 +19,7 @@ public class Tootle.Widgets.Conversation : Widgets.Status {
 		owned get {
 			var label = "";
 			foreach (API.Account account in conversation.accounts) {
-				label += "<b>" + Html.simplify (account.display_name) + "</b>";
+				label += "<b>" + HtmlUtils.simplify (account.display_name) + "</b>";
 				if (conversation.accounts.last () != account)
 					label += ", ";
 			}

--- a/src/Widgets/MarkupPolicy.vala
+++ b/src/Widgets/MarkupPolicy.vala
@@ -1,0 +1,27 @@
+public enum Tootle.MarkupPolicy {
+
+	// Remove all tags from the string
+	DISALLOW,
+
+	// Allow markup, remove unsupported tags from the input string
+	ALLOW,
+
+	// Allow markup, do nothing with the input string
+	TRUST;
+
+	public string process (string input) {
+		switch (this) {
+			case DISALLOW:
+				return HtmlUtils.remove_tags (input);
+			case ALLOW:
+				return HtmlUtils.simplify (input);
+			default:
+				return input;
+		}
+	}
+
+	public void apply (Widgets.RichLabel w) {
+		w.use_markup = this != DISALLOW;
+	}
+
+}

--- a/src/Widgets/MarkupView.vala
+++ b/src/Widgets/MarkupView.vala
@@ -18,6 +18,20 @@ public class Tootle.Widgets.MarkupView : Box {
 		}
 	}
 
+	private bool _selectable = false;
+	public bool selectable {
+		get { return _selectable; }
+		set {
+			_selectable = value;
+			get_children ().foreach (w => {
+				var label = w as Label;
+				if (label != null) {
+					label.selectable = _selectable;
+				}
+			});
+		}
+	}
+
 	construct {
 		orientation = Orientation.VERTICAL;
 		spacing = 12;
@@ -59,7 +73,8 @@ public class Tootle.Widgets.MarkupView : Box {
 		if (current_chunk != null && current_chunk != "") {
 			var label = new RichLabel (current_chunk) {
 				visible = true,
-				markup = MarkupPolicy.TRUST
+				markup = MarkupPolicy.TRUST,
+				selectable = _selectable
 			};
 			pack_start (label);
 		}

--- a/src/Widgets/MarkupView.vala
+++ b/src/Widgets/MarkupView.vala
@@ -2,10 +2,109 @@ using Gtk;
 
 public class Tootle.Widgets.MarkupView : Box {
 
-	public string content { get; set; default = ""; }
+	string? current_chunk = null;
+
+	string _content = "";
+	public string content {
+		get {
+			return _content;
+		}
+		set {
+			_content = value;
+			update_content (_content);
+		}
+	}
 
 	construct {
+		orientation = Orientation.VERTICAL;
+	}
 
+	void update_content (string content) {
+		var doc = Html.Doc.read_doc (content, "", "utf8");
+		if (doc == null) {
+			//warning ("No document found!");
+			delete doc;
+			return;
+		}
+
+		var root = doc->get_root_element ();
+		if (root == null) {
+			//warning ("No root node found!");
+			delete doc;
+			return;
+		}
+
+		handle_node (root);
+
+		delete doc;
+	}
+
+	public delegate void NodeCB (Xml.Node* node);
+	void traverse (Xml.Node* root, owned NodeCB cb) {
+		Xml.Node* iter;
+		for (iter = root->children; iter != null; iter = iter->next) {
+			//warning (iter->name);
+
+			// if (iter->content != null)
+			// 	warning (iter->content);
+
+			//handle_node (iter);
+			//traverse_node (iter);
+
+			cb (iter);
+		}
+	}
+
+	void commit_chunk () {
+		if (current_chunk != null && current_chunk != "") {
+			var label = new RichLabel (current_chunk) {
+				visible = true
+			};
+			pack_start (label);
+		}
+		current_chunk = null;
+	}
+
+	void write_chunk (string chunk) {
+		if (current_chunk == null)
+			current_chunk = chunk;
+		else
+			current_chunk += chunk;
+	}
+
+	void handle_node (Xml.Node* root) {
+		switch (root->name) {
+			case "html":
+				message ("===START DOC===");
+				traverse (root, (node) => {
+					handle_node (node);
+				});
+				message ("=== END DOC ===");
+				break;
+			case "body":
+				message (content);
+				traverse (root, (node) => {
+					handle_node (node);
+				});
+				commit_chunk ();
+				break;
+			case "br":
+				write_chunk ("\n");
+				break;
+			case "text":
+				message (root->content);
+				write_chunk (root->content);
+				break;
+			case "p":
+				commit_chunk ();
+				traverse (root, (node) => {
+					handle_node (node);
+				});
+				break;
+			default:
+				warning ("Unknown HTML tag: "+root->name);
+				break;
+		}
 	}
 
 }

--- a/src/Widgets/MarkupView.vala
+++ b/src/Widgets/MarkupView.vala
@@ -1,0 +1,11 @@
+using Gtk;
+
+public class Tootle.Widgets.MarkupView : Box {
+
+	public string content { get; set; default = ""; }
+
+	construct {
+
+	}
+
+}

--- a/src/Widgets/MarkupView.vala
+++ b/src/Widgets/MarkupView.vala
@@ -76,11 +76,9 @@ public class Tootle.Widgets.MarkupView : Box {
 	public static void default_handler (MarkupView v, Xml.Node* root) {
 		switch (root->name) {
 			case "html":
-				// message ("===START DOC===");
 				traverse (root, (node) => {
 					default_handler (v, node);
 				});
-				// message ("=== END DOC ===");
 				break;
 			case "body":
 				traverse (root, (node) => {
@@ -92,11 +90,12 @@ public class Tootle.Widgets.MarkupView : Box {
 				v.write_chunk ("\n");
 				break;
 			case "text":
-				message (root->content);
-				v.write_chunk (root->content);
+				v.write_chunk (GLib.Markup.escape_text (root->content));
 				break;
 			case "p":
-				v.commit_chunk ();
+				if (v.current_chunk != "" && v.current_chunk != null)
+					v.write_chunk ("\n\n");
+
 				traverse (root, (node) => {
 					default_handler (v, node);
 				});

--- a/src/Widgets/MarkupView.vala
+++ b/src/Widgets/MarkupView.vala
@@ -1,5 +1,4 @@
 using Gtk;
-using Gee;
 
 public class Tootle.Widgets.MarkupView : Box {
 
@@ -30,28 +29,20 @@ public class Tootle.Widgets.MarkupView : Box {
 		});
 
 		var doc = Html.Doc.read_doc (content, "", "utf8");
-		if (doc == null) {
-			//warning ("No document found!");
-			return;
+		if (doc != null) {
+			var root = doc->get_root_element ();
+			if (root != null) {
+				default_handler (this, root);
+			}
 		}
 
-		var root = doc->get_root_element ();
-		if (root == null) {
-			//warning ("No root node found!");
-			return;
-		}
-
-		//message (content);
-		default_handler (this, root);
-
-		//delete doc;
+		delete doc;
 
 		visible = get_children ().length () > 0;
 	}
 
 	static void traverse (Xml.Node* root, owned NodeFn cb) {
-		Xml.Node* iter;
-		for (iter = root->children; iter != null; iter = iter->next) {
+		for (var iter = root->children; iter != null; iter = iter->next) {
 			cb (iter);
 		}
 	}
@@ -75,8 +66,6 @@ public class Tootle.Widgets.MarkupView : Box {
 		else
 			current_chunk += chunk;
 	}
-
-
 
 	public static void default_handler (MarkupView v, Xml.Node* root) {
 		switch (root->name) {

--- a/src/Widgets/RichLabel.vala
+++ b/src/Widgets/RichLabel.vala
@@ -10,7 +10,7 @@ public class Tootle.Widgets.RichLabel : Label {
 			return this.label;
 		}
 		set {
-			this.label = escape_entities (Html.simplify (value));
+			this.label = escape_entities (HtmlUtils.simplify (value));
 		}
 	}
 

--- a/src/Widgets/RichLabel.vala
+++ b/src/Widgets/RichLabel.vala
@@ -3,19 +3,30 @@ using Gee;
 
 public class Tootle.Widgets.RichLabel : Label {
 
+	// TODO: We can parse <a> tags and extract resolvable URIs now
 	public weak ArrayList<API.Mention>? mentions;
+
+	MarkupPolicy _markup = DISALLOW;
+	public MarkupPolicy markup {
+		get {
+			return _markup;
+		}
+		set {
+			_markup = value;
+			_markup.apply (this);
+		}
+	}
 
 	public string text {
 		get {
 			return this.label;
 		}
 		set {
-			this.label = escape_entities (HtmlUtils.simplify (value));
+			this.label = markup.process (value);
 		}
 	}
 
 	construct {
-		use_markup = true;
 		xalign = 0;
 		wrap_mode = Pango.WrapMode.WORD_CHAR;
 		justify = Justification.LEFT;

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -51,7 +51,7 @@ public class Tootle.Widgets.Status : ListBoxRow {
 	[GtkChild] protected Box content_column;
 	[GtkChild] protected Stack spoiler_stack;
 	[GtkChild] protected Box content_box;
-	[GtkChild] protected Widgets.RichLabel content;
+	[GtkChild] protected Widgets.MarkupView content;
 	[GtkChild] protected Widgets.Attachment.Box attachments;
 	[GtkChild] protected Button spoiler_button;
 	[GtkChild] protected Widgets.RichLabel spoiler_label;
@@ -140,7 +140,7 @@ public class Tootle.Widgets.Status : ListBoxRow {
 			reply_button_icon.icon_name = "mail-reply-sender-symbolic";
 
 		bind_property ("spoiler-text", spoiler_label, "text", BindingFlags.SYNC_CREATE);
-		status.formal.bind_property ("content", content, "text", BindingFlags.SYNC_CREATE);
+		status.formal.bind_property ("content", content, "content", BindingFlags.SYNC_CREATE);
 		bind_property ("title_text", name_label, "text", BindingFlags.SYNC_CREATE);
 		bind_property ("subtitle_text", handle_label, "text", BindingFlags.SYNC_CREATE);
 		bind_property ("date", date_label, "label", BindingFlags.SYNC_CREATE);
@@ -166,9 +166,11 @@ public class Tootle.Widgets.Status : ListBoxRow {
 		if (status.id == "") {
 			actions.destroy ();
 			date_label.destroy ();
-			content.single_line_mode = true;
-			content.lines = 2;
-			content.ellipsize = Pango.EllipsizeMode.END;
+
+			//TODO: this
+			// content.single_line_mode = true;
+			// content.lines = 2;
+			// content.ellipsize = Pango.EllipsizeMode.END;
 		}
 
 		if (!attachments.populate (status.formal.media_attachments) || status.id == "") {
@@ -261,7 +263,7 @@ public class Tootle.Widgets.Status : ListBoxRow {
 
 	public void expand_root () {
 		activatable = false;
-        content.selectable = true;
+        // content.selectable = true; //TODO: this
         content.get_style_context ().add_class ("ttl-large-body");
 
         var parent = content_column.get_parent () as Container;

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -42,9 +42,9 @@ public class Tootle.Widgets.Status : ListBoxRow {
 
 	[GtkChild] public Widgets.Avatar avatar;
 	[GtkChild] protected Widgets.RichLabel name_label;
-	[GtkChild] protected Widgets.RichLabel handle_label;
+	[GtkChild] protected Label handle_label;
 	[GtkChild] protected Box indicators;
-	[GtkChild] protected Widgets.RichLabel date_label;
+	[GtkChild] protected Label date_label;
 	[GtkChild] protected Image pin_indicator;
 	[GtkChild] protected Image indicator;
 
@@ -84,7 +84,7 @@ public class Tootle.Widgets.Status : ListBoxRow {
 
 	public string title_text {
 		owned get {
-			return HtmlUtils.simplify (status.formal.account.display_name);
+			return status.formal.account.display_name;
 		}
 	}
 
@@ -142,7 +142,7 @@ public class Tootle.Widgets.Status : ListBoxRow {
 		bind_property ("spoiler-text", spoiler_label, "text", BindingFlags.SYNC_CREATE);
 		status.formal.bind_property ("content", content, "content", BindingFlags.SYNC_CREATE);
 		bind_property ("title_text", name_label, "text", BindingFlags.SYNC_CREATE);
-		bind_property ("subtitle_text", handle_label, "text", BindingFlags.SYNC_CREATE);
+		bind_property ("subtitle_text", handle_label, "label", BindingFlags.SYNC_CREATE);
 		bind_property ("date", date_label, "label", BindingFlags.SYNC_CREATE);
 		status.formal.bind_property ("pinned", pin_indicator, "visible", BindingFlags.SYNC_CREATE);
 		status.formal.bind_property ("account", avatar, "account", BindingFlags.SYNC_CREATE);
@@ -180,7 +180,7 @@ public class Tootle.Widgets.Status : ListBoxRow {
 		menu_button.clicked.connect (open_menu);
 	}
 
-	public Status (API.Status status, API.NotificationType? kind = null) {
+	public Status (owned API.Status status, API.NotificationType? kind = null) {
 		Object (
 			status: status,
 			kind: kind

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -263,7 +263,7 @@ public class Tootle.Widgets.Status : ListBoxRow {
 
 	public void expand_root () {
 		activatable = false;
-        // content.selectable = true; //TODO: this
+        content.selectable = true;
         content.get_style_context ().add_class ("ttl-large-body");
 
         var parent = content_column.get_parent () as Container;

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -263,14 +263,14 @@ public class Tootle.Widgets.Status : ListBoxRow {
 
 	public void expand_root () {
 		activatable = false;
-        content.selectable = true;
-        content.get_style_context ().add_class ("ttl-large-body");
+		content.selectable = true;
+		content.get_style_context ().add_class ("ttl-large-body");
 
-        var parent = content_column.get_parent () as Container;
-        var left_attach = parent.find_child_property ("left-attach");
-        var width = parent.find_child_property ("width");
-        parent.set_child_property (content_column, 1, 0, left_attach);
-        parent.set_child_property (content_column, 3, 2, width);
+		var parent = content_column.get_parent () as Container;
+		var left_attach = parent.find_child_property ("left-attach");
+		var width = parent.find_child_property ("width");
+		parent.set_child_property (content_column, 1, 0, left_attach);
+		parent.set_child_property (content_column, 3, 2, width);
 	}
 
 	public void install_thread_line () {

--- a/src/Widgets/Status.vala
+++ b/src/Widgets/Status.vala
@@ -84,7 +84,7 @@ public class Tootle.Widgets.Status : ListBoxRow {
 
 	public string title_text {
 		owned get {
-			return Html.simplify (status.formal.account.display_name);
+			return HtmlUtils.simplify (status.formal.account.display_name);
 		}
 	}
 
@@ -218,7 +218,7 @@ public class Tootle.Widgets.Status : ListBoxRow {
 		item_copy_link.activate.connect (() => Desktop.copy (status.formal.url));
 		var item_copy = new Gtk.MenuItem.with_label (_("Copy Text"));
 		item_copy.activate.connect (() => {
-			var sanitized = Html.remove_tags (status.formal.content);
+			var sanitized = HtmlUtils.remove_tags (status.formal.content);
 			Desktop.copy (sanitized);
 		});
 


### PR DESCRIPTION
This PR is supposed to fix #235, #262 & #44

- [x] Depend on `libxml2`
- [x] Introduce a new widget class: `MarkupView`
- [x] Replace the old `RichLabel` widget in the post widget
- [x] Support text selection for `Views.Thread` & `Views.Profile`

Supported tags:
- [x] span
- [x] a
- [x] p
- [x] br
- [x] markup 
- [x] ul
- [x] ol
- [x] li 
- [x] blockquote
- [x] b, i, sup, sub, u