### PR TITLE
About dialog: close when the close button is pressed

### DIFF
--- a/src/Dialogs/About.vala
+++ b/src/Dialogs/About.vala
@@ -22,6 +22,13 @@ public class Tootle.Dialogs.About : AboutDialog {
 		artists = Build.get_artists ();
 		translator_credits = Build.TRANSLATOR != " " ? Build.TRANSLATOR : null;
 
+		response.connect ((response_id) => {
+			if (response_id == Gtk.ResponseType.CANCEL || 
+			    response_id == Gtk.ResponseType.DELETE_EVENT) {
+				hide_on_delete ();
+			}
+		});
+
 		present ();
 	}
 


### PR DESCRIPTION
Hi,

Well, the title says it all, i added a connector so the close button really closes the about dialog.

Note that i don't know a thing about vala, i just followed the [docs](https://valadoc.org/gtk+-3.0/Gtk.AboutDialog.html) :)

Fixes #242.