### PR TITLE
i18n: Fix lines that remain untranslated

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,7 @@ add_global_arguments([
 config = configuration_data()
 config.set('EXEC_NAME', meson.project_name())
 config.set('GETTEXT_PACKAGE', meson.project_name())
+config.set('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
 config.set('RESOURCES', '/' + '/'.join(meson.project_name().split('.')) + '/' )
 config.set('VERSION', meson.project_version())
 config.set('PREFIX', get_option('prefix'))

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -73,6 +73,11 @@ namespace Tootle {
 				warning (e.message);
 			}
 
+			Intl.setlocale (LocaleCategory.ALL, "");
+			Intl.bindtextdomain (Build.GETTEXT_PACKAGE, Build.LOCALEDIR);
+			Intl.bind_textdomain_codeset (Build.GETTEXT_PACKAGE, "UTF-8");
+			Intl.textdomain (Build.GETTEXT_PACKAGE);
+
 			app = new Application ();
 			return app.run (args);
 		}

--- a/src/Build.vala.in
+++ b/src/Build.vala.in
@@ -8,6 +8,8 @@ public class Build {
 	public const string SUPPORT_WEBSITE = "@SUPPORT_WEBSITE@";
 	public const string COPYRIGHT = "@COPYRIGHT@";
 	public const string PREFIX = "@PREFIX@";
+	public const string GETTEXT_PACKAGE = "@GETTEXT_PACKAGE@";
+	public const string LOCALEDIR = "@LOCALEDIR@";
 
 	public static string SYSTEM_INFO;
 


### PR DESCRIPTION
As it was already mentioned in #287 and #289, some lines still remain untranslated even if they are.
This commit fixes it! Here's the [source](https://www.gnu.org/software/gettext/FAQ.html#integrating_howto).
Please, feel free to change commit message or code, as I'm not familiar with Vala.