### PR TITLE
Use reason_phrase instead of get_phrase

### DIFF
--- a/src/Services/Cache.vala
+++ b/src/Services/Cache.vala
@@ -88,7 +88,7 @@ public class Tootle.Cache : GLib.Object {
                 try {
                     var code = msg.status_code;
 					if (code != Soup.Status.OK) {
-					    var error = network.describe_error (code);
+					    var error = msg.reason_phrase;
 					    throw new Oopsie.INSTANCE (@"Server returned $error");
 					}
 

--- a/src/Services/Network.vala
+++ b/src/Services/Network.vala
@@ -56,7 +56,7 @@ public class Tootle.Network : GLib.Object {
                 else if (status == Soup.Status.CANCELLED)
                     debug ("Message is cancelled. Ignoring callback invocation.");
                 else
-                    ecb ((int32) status, describe_error ((int32) status));
+                    ecb ((int32) status, msg.reason_phrase);
             });
         }
         catch (Error e) {
@@ -64,11 +64,6 @@ public class Tootle.Network : GLib.Object {
             ecb (0, e.message);
         }
     }
-
-	public string describe_error (uint code) {
-	    var reason = Soup.Status.get_phrase (code);
-		return @"$code: $reason";
-	}
 
     public void on_error (int32 code, string message) {
         warning (message);


### PR DESCRIPTION
This is a fix for issue #320.

Since you have no stable branch, I opened this PR against `master`, but it is based on tag `1.0`.

The use `get_phrase` is discouraged in the documentation. And `reason_phrase` has the advantage of being localized already.