### PR TITLE
Adhere to GLib.Object naming conventions for properties

### DIFF
--- a/src/API/Attachment.vala
+++ b/src/API/Attachment.vala
@@ -4,10 +4,10 @@ public class Tootle.API.Attachment : Entity, Widgetizable {
 	public string kind { get; set; default = "unknown"; }
 	public string url { get; set; }
 	public string? description { get; set; }
-	public string? _preview_url { get; set; }
+	private string? t_preview_url { get; set; }
 	public string? preview_url {
-		set { this._preview_url = value; }
-		get { return (this._preview_url == null || this._preview_url == "") ? url : _preview_url; }
+		set { this.t_preview_url = value; }
+		get { return (this.t_preview_url == null || this.t_preview_url == "") ? url : t_preview_url; }
 	}
 
 	public File? source_file { get; set; }

--- a/src/API/Status.vala
+++ b/src/API/Status.vala
@@ -28,16 +28,16 @@ public class Tootle.API.Status : Entity, Widgetizable {
     public ArrayList<API.Mention>? mentions { get; set; default = null; }
     public ArrayList<API.Attachment>? media_attachments { get; set; default = null; }
 
-    public string? _url { get; set; }
+    private string? t_url { get; set; }
     public string url {
         owned get { return this.get_modified_url (); }
-        set { this._url = value; }
+        set { this.t_url = value; }
     }
     string get_modified_url () {
-        if (this._url == null) {
+        if (this.t_url == null) {
             return this.uri.replace ("/activity", "");
         }
-        return this._url;
+        return this.t_url;
     }
 
     public Status formal {


### PR DESCRIPTION
Vala now validates property names against GLib.Object conventions, this
fixes a compilation error as a result of this enforcement:

../src/API/Status.vala:27.5-27.23: error: Name `_url' is not valid for a GLib.Object property
    public string? _url { get; set; }
    ^^^^^^^^^^^^^^^^^^^

Relevant Vala change:
https://gitlab.gnome.org/GNOME/vala/-/commit/38d61fbff037687ea4772e6df85c7e22a74b335e

fixes #337

Signed-off-by: Clayton Craft <clayton@craftyguy.net>