### PR TITLE
Polish the messages list borders

### DIFF
--- a/data/app.css
+++ b/data/app.css
@@ -50,6 +50,10 @@
 	border-top: 0px;
 }
 
+.ttl-view .large {
+	margin-left: 18px;
+	margin-right: 18px;
+}
 .ttl-view .large:first-child {
 	margin-top: 32px;
 }

--- a/data/app.css
+++ b/data/app.css
@@ -39,6 +39,11 @@
 	padding: 0px;
 }
 
+.ttl-view .small .content {
+	border: none;
+	border-radius: 0;
+}
+
 .ttl-view .small .content row {
 	border-left: none;
 	border-right: none;

--- a/data/app.css
+++ b/data/app.css
@@ -42,6 +42,7 @@
 .ttl-view .small .content {
 	border: none;
 	border-radius: 0;
+	transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
 .ttl-view .small .content row {
@@ -53,6 +54,10 @@
 /* Hides the top border from the first row of the first listbox */
 .ttl-view .small :first-child list row:first-child {
 	border-top: 0px;
+}
+
+.ttl-view clamp > * {
+	transition: all 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
 .ttl-view .large {

--- a/data/ui/views/base.ui
+++ b/data/ui/views/base.ui
@@ -33,8 +33,8 @@
                     <property name="vexpand">1</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="maximum_size">650</property>
-                    <property name="tightening_threshold">650</property>
+                    <property name="maximum_size">670</property>
+                    <property name="tightening_threshold">670</property>
                     <child>
                       <object class="GtkBox" id="column_view">
                         <property name="orientation">vertical</property>


### PR DESCRIPTION
This avoids double-borders when the messages list is small, gives it some horizontal margins, and gives a smooth small-large state transition.