### PR TITLE
Application: make app_entries private

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -43,7 +43,7 @@ namespace Tootle {
 			{ null }
 		};
 
-		public const GLib.ActionEntry[] app_entries = {
+		private const GLib.ActionEntry[] app_entries = {
 			{ "about", about_activated },
 			{ "compose", compose_activated },
 			{ "back", back_activated },


### PR DESCRIPTION
Fixes compilation with latest valac (0.56), otherwise build fails with

```
../src/Application.vala:46.49-53.3: error: value is less accessible than constant `Tootle.Application.app_entries'
   46 |                 public const GLib.ActionEntry[] app_entries = {
      |                                                               ^
   47 |                         { "about", about_activated },
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   48 |                         { "compose", compose_activated },
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   49 |                         { "back", back_activated },
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
   50 |                         { "refresh", refresh_activated },
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   51 |                         { "search", search_activated },
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   52 |                         { "switch-timeline", switch_timeline_activated, "i" }
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   53 |                 };
      |                 ~ 
Compilation failed: 1 error(s), 129 warning(s)
ninja: build stopped: subcommand failed.
```

(Note that we are also patch is app with #339 and #336, they are likely also needed to make this build with latest vala)

See also: https://github.com/elementary/mail/pull/765